### PR TITLE
Fix old bug in setting default options

### DIFF
--- a/plugin/Phpqa.vim
+++ b/plugin/Phpqa.vim
@@ -86,7 +86,7 @@ endif
 " Whether to show signs for covered code (or only not covered)
 " It may speed things up to turn this off
 if !exists("g:phpqa_codecoverage_regex")
-    let g:phpqa_codecoverage_showcovered = 1
+    let g:phpqa_codecoverage_regex = 1
 endif
 
 " Whether to automatically run codesniffer when saving a file


### PR DESCRIPTION
Hi Mark, thanks for contributing your python3 patch. It's working fine here. Because I can finally use joonty's plugin for codecov, I found the indicated minor bug and figured I would send it back your way. There are lots of unanswered PRs on joonty's repo so this might not get included any time soon. Will you plan to update your master and maintain the fork for the time being?